### PR TITLE
fix: [#4] Adapt the current solution for jsonrpcclient v4.x

### DIFF
--- a/pycspr/api/get_account_balance.py
+++ b/pycspr/api/get_account_balance.py
@@ -1,6 +1,7 @@
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr import types
 from pycspr.api import constants
@@ -23,11 +24,11 @@ def execute(
     """
     state_root_hash = state_root_hash.hex() if state_root_hash else None
 
-    response = rpc_client.request(
+    response = requests.post(
         connection_info.address_rpc,
-        constants.RPC_STATE_GET_BALANCE,
+        json=request(constants.RPC_STATE_GET_BALANCE),
         purse_uref=purse_uref.as_string(),
         state_root_hash=state_root_hash,
         )
 
-    return int(response.data.result["balance_value"])
+    return int(parse(response.json()).result["balance_value"])

--- a/pycspr/api/get_account_balance.py
+++ b/pycspr/api/get_account_balance.py
@@ -26,9 +26,9 @@ def execute(
 
     response = requests.post(
         connection_info.address_rpc,
-        json=request(constants.RPC_STATE_GET_BALANCE),
-        purse_uref=purse_uref.as_string(),
-        state_root_hash=state_root_hash,
+        json=request(constants.RPC_STATE_GET_BALANCE,
+        {"purse_uref":purse_uref.as_string(),
+        "state_root_hash":state_root_hash}),
         )
 
     return int(parse(response.json()).result["balance_value"])

--- a/pycspr/api/get_account_info.py
+++ b/pycspr/api/get_account_info.py
@@ -25,30 +25,30 @@ def execute(
     if isinstance(block_id, type(None)):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_STATE_GET_ACCOUNT_INFO),
-            public_key=account_key.hex(),
+            json=request(constants.RPC_STATE_GET_ACCOUNT_INFO,
+            {"public_key":account_key.hex()})
             )
 
     # Get by hash - bytes | hex.
     elif isinstance(block_id, (bytes, str)):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_STATE_GET_ACCOUNT_INFO),
-            public_key=account_key.hex(),
-            block_identifier={
+            json=request(constants.RPC_STATE_GET_ACCOUNT_INFO,
+            {"public_key":account_key.hex(),
+            "block_identifier":{
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
-            }
+            }})
         )
 
     # Get by height.
     elif isinstance(block_id, int):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_STATE_GET_ACCOUNT_INFO),
-            public_key=account_key.hex(),
-            block_identifier={
+            json=request(constants.RPC_STATE_GET_ACCOUNT_INFO,
+            {"public_key":account_key.hex(),
+            "block_identifier":{
                 "Height": block_id
-            }
+            }})
         )
     
     return parse(response.json()).result["account"]

--- a/pycspr/api/get_account_info.py
+++ b/pycspr/api/get_account_info.py
@@ -1,6 +1,7 @@
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -22,17 +23,17 @@ def execute(
     """    
     # Get latest.
     if isinstance(block_id, type(None)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_STATE_GET_ACCOUNT_INFO,
+            json=request(constants.RPC_STATE_GET_ACCOUNT_INFO),
             public_key=account_key.hex(),
             )
 
     # Get by hash - bytes | hex.
     elif isinstance(block_id, (bytes, str)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_STATE_GET_ACCOUNT_INFO, 
+            json=request(constants.RPC_STATE_GET_ACCOUNT_INFO),
             public_key=account_key.hex(),
             block_identifier={
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
@@ -41,13 +42,13 @@ def execute(
 
     # Get by height.
     elif isinstance(block_id, int):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_STATE_GET_ACCOUNT_INFO, 
+            json=request(constants.RPC_STATE_GET_ACCOUNT_INFO),
             public_key=account_key.hex(),
             block_identifier={
                 "Height": block_id
             }
         )
     
-    return response.data.result["account"]
+    return parse(response.json()).result["account"]

--- a/pycspr/api/get_auction_info.py
+++ b/pycspr/api/get_auction_info.py
@@ -1,6 +1,7 @@
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.api.get_block import execute as get_block
@@ -27,9 +28,9 @@ def execute(
 
     # Get by hash - bytes | hex.
     if isinstance(block_id, (bytes, str)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_STATE_GET_AUCTION_INFO, 
+            json=request(constants.RPC_STATE_GET_AUCTION_INFO),
             block_identifier={
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
             }
@@ -37,12 +38,12 @@ def execute(
 
     # Get by height.
     elif isinstance(block_id, int):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_STATE_GET_AUCTION_INFO, 
+            json=request(constants.RPC_STATE_GET_AUCTION_INFO),
             block_identifier={
                 "Height": block_id
             }
         )
 
-    return response.data.result
+    return parse(response.json()).result

--- a/pycspr/api/get_auction_info.py
+++ b/pycspr/api/get_auction_info.py
@@ -30,20 +30,20 @@ def execute(
     if isinstance(block_id, (bytes, str)):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_STATE_GET_AUCTION_INFO),
+            json=request(constants.RPC_STATE_GET_AUCTION_INFO,
             block_identifier={
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
-            }
+            })
         )
 
     # Get by height.
     elif isinstance(block_id, int):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_STATE_GET_AUCTION_INFO),
+            json=request(constants.RPC_STATE_GET_AUCTION_INFO,
             block_identifier={
                 "Height": block_id
-            }
+            })
         )
 
     return parse(response.json()).result

--- a/pycspr/api/get_block.py
+++ b/pycspr/api/get_block.py
@@ -30,20 +30,20 @@ def execute(
     elif isinstance(block_id, (bytes, str)):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_CHAIN_GET_BLOCK),
-            block_identifier={
+            json=request(constants.RPC_CHAIN_GET_BLOCK,
+                {"block_identifier":{
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
-            }
+            }})
         )
 
     # Get by height.
     elif isinstance(block_id, int):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_CHAIN_GET_BLOCK),
-            block_identifier={
+            json=request(constants.RPC_CHAIN_GET_BLOCK,
+                {"block_identifier":{
                 "Height": block_id
-            }
+            }})
         )
 
     return parse(response.json()).result["block"]

--- a/pycspr/api/get_block.py
+++ b/pycspr/api/get_block.py
@@ -1,6 +1,7 @@
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -20,16 +21,16 @@ def execute(
     """
     # Get latest.
     if isinstance(block_id, type(None)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_BLOCK
+            json=request(constants.RPC_CHAIN_GET_BLOCK)
             )
 
     # Get by hash - bytes | hex.
     elif isinstance(block_id, (bytes, str)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_BLOCK, 
+            json=request(constants.RPC_CHAIN_GET_BLOCK),
             block_identifier={
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
             }
@@ -37,12 +38,12 @@ def execute(
 
     # Get by height.
     elif isinstance(block_id, int):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_BLOCK, 
+            json=request(constants.RPC_CHAIN_GET_BLOCK),
             block_identifier={
                 "Height": block_id
             }
         )
 
-    return response.data.result["block"]
+    return parse(response.json()).result["block"]

--- a/pycspr/api/get_block_transfers.py
+++ b/pycspr/api/get_block_transfers.py
@@ -30,20 +30,20 @@ def execute(
     elif isinstance(block_id, (bytes, str)):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_CHAIN_GET_BLOCK_TRANSFERS),
+            json=request(constants.RPC_CHAIN_GET_BLOCK_TRANSFERS,
             block_identifier={
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
-            }
+            })
         )
 
     # Get by height.
     elif isinstance(block_id, int):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_CHAIN_GET_BLOCK_TRANSFERS),
+            json=request(constants.RPC_CHAIN_GET_BLOCK_TRANSFERS,
             block_identifier={
                 "Height": block_id
-            }
+            })
         )
    
     parsed = parse(response.json())

--- a/pycspr/api/get_block_transfers.py
+++ b/pycspr/api/get_block_transfers.py
@@ -1,6 +1,7 @@
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -20,16 +21,16 @@ def execute(
     """
     # Get latest.
     if isinstance(block_id, type(None)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_BLOCK_TRANSFERS
+            json=request(constants.RPC_CHAIN_GET_BLOCK_TRANSFERS)
             )
 
     # Get by hash - bytes | hex.
     elif isinstance(block_id, (bytes, str)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_BLOCK_TRANSFERS, 
+            json=request(constants.RPC_CHAIN_GET_BLOCK_TRANSFERS),
             block_identifier={
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
             }
@@ -37,15 +38,16 @@ def execute(
 
     # Get by height.
     elif isinstance(block_id, int):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_BLOCK_TRANSFERS, 
+            json=request(constants.RPC_CHAIN_GET_BLOCK_TRANSFERS),
             block_identifier={
                 "Height": block_id
             }
         )
-    
+   
+    parsed = parse(response.json())
     return (
-        response.data.result["block_hash"],
-        response.data.result["transfers"],
+        parsed.result["block_hash"],
+        parsed.result["transfers"],
     )

--- a/pycspr/api/get_deploy.py
+++ b/pycspr/api/get_deploy.py
@@ -1,6 +1,7 @@
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -20,10 +21,10 @@ def execute(
 
     """
     deploy_id = deploy_id.hex() if isinstance(deploy_id, bytes) else deploy_id
-    response = rpc_client.request(
+    response = requests.post(
         connection_info.address_rpc,
-        constants.RPC_INFO_GET_DEPLOY, 
+        json=request(constants.RPC_INFO_GET_DEPLOY),
         deploy_hash=deploy_id
     )
 
-    return response.data.result["deploy"]
+    return parse(response.json()).result["deploy"]

--- a/pycspr/api/get_deploy.py
+++ b/pycspr/api/get_deploy.py
@@ -23,8 +23,8 @@ def execute(
     deploy_id = deploy_id.hex() if isinstance(deploy_id, bytes) else deploy_id
     response = requests.post(
         connection_info.address_rpc,
-        json=request(constants.RPC_INFO_GET_DEPLOY),
-        deploy_hash=deploy_id
+        json=request(constants.RPC_INFO_GET_DEPLOY,
+        {"deploy_hash":deploy_id})
     )
 
     return parse(response.json()).result["deploy"]

--- a/pycspr/api/get_dictionary_item.py
+++ b/pycspr/api/get_dictionary_item.py
@@ -1,4 +1,5 @@
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr import types
 from pycspr.api import constants
@@ -18,9 +19,9 @@ def execute(
 
     """
     if isinstance(identifer, type.DictionaryIdentifier_AccountNamedKey):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_STATE_GET_DICTIONARY_ITEM, 
+            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM),
             AccountNamedKey={
                 "dictionary_item_key": identifier.dictionary_item_key,
                 "dictionary_name": identifier.dictionary_name,
@@ -29,9 +30,9 @@ def execute(
         )
 
     elif isinstance(identifer, type.DictionaryIdentifier_ContractNamedKey):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_STATE_GET_DICTIONARY_ITEM, 
+            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM),
             ContractNamedKey={
                 "dictionary_item_key": identifier.dictionary_item_key,
                 "dictionary_name": identifier.dictionary_name,
@@ -40,9 +41,9 @@ def execute(
         )
 
     elif isinstance(identifer, type.DictionaryIdentifier_SeedURef):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_STATE_GET_DICTIONARY_ITEM, 
+            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM),
             URef={
                 "dictionary_item_key": identifier.dictionary_item_key,
                 "seed_uref": identifier.dictionary_name
@@ -50,9 +51,9 @@ def execute(
         )
 
     elif isinstance(identifer, type.DictionaryIdentifier_UniqueKey):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_STATE_GET_DICTIONARY_ITEM, 
+            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM),
             Dictionary=identifier.seed_uref.as_string()
         )
 

--- a/pycspr/api/get_dictionary_item.py
+++ b/pycspr/api/get_dictionary_item.py
@@ -21,40 +21,40 @@ def execute(
     if isinstance(identifer, type.DictionaryIdentifier_AccountNamedKey):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM),
-            AccountNamedKey={
+            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM,
+            {"AccountNamedKey":{
                 "dictionary_item_key": identifier.dictionary_item_key,
                 "dictionary_name": identifier.dictionary_name,
                 "key": identifier.key
-            }
+            }})
         )
 
     elif isinstance(identifer, type.DictionaryIdentifier_ContractNamedKey):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM),
-            ContractNamedKey={
+            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM,
+            {"ContractNamedKey":{
                 "dictionary_item_key": identifier.dictionary_item_key,
                 "dictionary_name": identifier.dictionary_name,
                 "key": identifier.key
-            }
+            }})
         )
 
     elif isinstance(identifer, type.DictionaryIdentifier_SeedURef):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM),
-            URef={
+            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM,
+            {"URef":{
                 "dictionary_item_key": identifier.dictionary_item_key,
                 "seed_uref": identifier.dictionary_name
-            }
+            }})
         )
 
     elif isinstance(identifer, type.DictionaryIdentifier_UniqueKey):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM),
-            Dictionary=identifier.seed_uref.as_string()
+            json=request(constants.RPC_STATE_GET_DICTIONARY_ITEM,
+            {"Dictionary":identifier.seed_uref.as_string()})
         )
 
     else:

--- a/pycspr/api/get_era_info.py
+++ b/pycspr/api/get_era_info.py
@@ -1,6 +1,7 @@
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -20,16 +21,16 @@ def execute(
     """
     # Get latest.
     if isinstance(block_id, type(None)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK
+            json=request(constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK)
             )
 
     # Get by hash - bytes | hex.
     elif isinstance(block_id, (bytes, str)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK, 
+            json=request(constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK),
             block_identifier={
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
             }
@@ -37,12 +38,12 @@ def execute(
 
     # Get by height.
     elif isinstance(block_id, int):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK, 
+            json=request(constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK),
             block_identifier={
                 "Height": block_id
             }
         )    
 
-    return response.data.result["era_summary"]
+    return parse(response.json()).result["era_summary"]

--- a/pycspr/api/get_era_info.py
+++ b/pycspr/api/get_era_info.py
@@ -30,20 +30,20 @@ def execute(
     elif isinstance(block_id, (bytes, str)):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK),
-            block_identifier={
+            json=request(constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK,
+            {"block_identifier":{
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
-            }
+            }})
         )
 
     # Get by height.
     elif isinstance(block_id, int):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK),
-            block_identifier={
+            json=request(constants.RPC_CHAIN_GET_ERA_INFO_BY_SWITCH_BLOCK,
+            {"block_identifier":{
                 "Height": block_id
-            }
+            }})
         )    
 
     return parse(response.json()).result["era_summary"]

--- a/pycspr/api/get_node_peers.py
+++ b/pycspr/api/get_node_peers.py
@@ -1,4 +1,5 @@
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -12,9 +13,9 @@ def execute(connection_info: NodeConnectionInfo) -> dict:
     :returns: Node peers information.
 
     """
-    response = rpc_client.request(
+    response = requests.post(
         connection_info.address_rpc,
-        constants.RPC_INFO_GET_PEERS
+        json=request(constants.RPC_INFO_GET_PEERS)
         )
 
-    return response.data.result["peers"]
+    return parse(response.json()).result["peers"]

--- a/pycspr/api/get_node_status.py
+++ b/pycspr/api/get_node_status.py
@@ -1,4 +1,5 @@
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -12,9 +13,9 @@ def execute(connection_info: NodeConnectionInfo) -> dict:
     :returns: Node status information.
 
     """
-    response = rpc_client.request(
+    response = requests.post(
         connection_info.address_rpc,
-        constants.RPC_INFO_GET_STATUS
+        json=request(constants.RPC_INFO_GET_STATUS)
         )
 
-    return response.data.result
+    return parse(response.json()).result

--- a/pycspr/api/get_rpc_schema.py
+++ b/pycspr/api/get_rpc_schema.py
@@ -1,4 +1,5 @@
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 import pycspr
 from pycspr.api import constants
@@ -13,9 +14,9 @@ def execute(connection_info: NodeConnectionInfo) -> dict:
     :returns: Node RPC API schema.
 
     """
-    response = rpc_client.request(
+    response = requests.post(
         connection_info.address_rpc,
-        constants.RPC_DISCOVER
+        json=request(constants.RPC_DISCOVER)
         )
 
-    return response.data.result["schema"]
+    return parse(response.json()).result["schema"]

--- a/pycspr/api/get_state_item.py
+++ b/pycspr/api/get_state_item.py
@@ -27,10 +27,10 @@ def execute(
     state_root_hash = state_root_hash.hex() if state_root_hash else None
     response = requests.post(
         connection_info.address_rpc,
-        json=request(constants.RPC_STATE_GET_ITEM),
-        key=item_key,
-        path=item_path,
-        state_root_hash=state_root_hash,
+        json=request(constants.RPC_STATE_GET_ITEM,
+        {"key":item_key,
+            "path":item_path,
+            "state_root_hash":state_root_hash})
         )
 
     return parse(response.json()).result["stored_value"]

--- a/pycspr/api/get_state_item.py
+++ b/pycspr/api/get_state_item.py
@@ -1,6 +1,7 @@
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -24,12 +25,12 @@ def execute(
     """
     item_path = item_path if isinstance(item_path, list) else [item_path]
     state_root_hash = state_root_hash.hex() if state_root_hash else None
-    response = rpc_client.request(
+    response = requests.post(
         connection_info.address_rpc,
-        constants.RPC_STATE_GET_ITEM,
+        json=request(constants.RPC_STATE_GET_ITEM),
         key=item_key,
         path=item_path,
         state_root_hash=state_root_hash,
         )
 
-    return response.data.result["stored_value"]
+    return parse(response.json()).result["stored_value"]

--- a/pycspr/api/get_state_root_hash.py
+++ b/pycspr/api/get_state_root_hash.py
@@ -1,6 +1,7 @@
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -20,16 +21,16 @@ def execute(
     """
     # Get latest.
     if isinstance(block_id, type(None)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_STATE_ROOT_HASH
+            json=request(constants.RPC_CHAIN_GET_STATE_ROOT_HASH)
             )
 
     # Get by hash - bytes | hex.
     elif isinstance(block_id, (bytes, str)):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc,
-            constants.RPC_CHAIN_GET_STATE_ROOT_HASH, 
+            json=request(constants.RPC_CHAIN_GET_STATE_ROOT_HASH),
             block_identifier={
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
             }
@@ -37,12 +38,12 @@ def execute(
 
     # Get by height.
     elif isinstance(block_id, int):
-        response = rpc_client.request(
+        response = requests.post(
             connection_info.address_rpc, 
-            constants.RPC_CHAIN_GET_STATE_ROOT_HASH, 
+            json=request(constants.RPC_CHAIN_GET_STATE_ROOT_HASH),
             block_identifier={
                 "Height": block_id
             }
         )
 
-    return response.data.result["state_root_hash"]
+    return parse(response.json()).result["state_root_hash"]

--- a/pycspr/api/get_state_root_hash.py
+++ b/pycspr/api/get_state_root_hash.py
@@ -30,20 +30,20 @@ def execute(
     elif isinstance(block_id, (bytes, str)):
         response = requests.post(
             connection_info.address_rpc,
-            json=request(constants.RPC_CHAIN_GET_STATE_ROOT_HASH),
-            block_identifier={
+            json=request(constants.RPC_CHAIN_GET_STATE_ROOT_HASH,
+            {"block_identifier":{
                 "Hash": block_id.hex() if isinstance(block_id, bytes) else block_id
-            }
+            }})
         )
 
     # Get by height.
     elif isinstance(block_id, int):
         response = requests.post(
             connection_info.address_rpc, 
-            json=request(constants.RPC_CHAIN_GET_STATE_ROOT_HASH),
-            block_identifier={
+            json=request(constants.RPC_CHAIN_GET_STATE_ROOT_HASH,
+            {"block_identifier":{
                 "Height": block_id
-            }
+            }})
         )
 
     return parse(response.json()).result["state_root_hash"]

--- a/pycspr/api/put_deploy.py
+++ b/pycspr/api/put_deploy.py
@@ -1,7 +1,8 @@
 import json
 import typing
 
-import jsonrpcclient as rpc_client
+from jsonrpcclient import parse, request
+import requests
 
 from pycspr.api import constants
 from pycspr.client import NodeConnectionInfo
@@ -18,10 +19,10 @@ def execute(connection_info: NodeConnectionInfo, deploy: Deploy) -> str:
     :returns: Hash of dispatched deploy.
 
     """
-    response = rpc_client.request(
+    response = requests.post(
         connection_info.address_rpc,
-        constants.RPC_ACCOUNT_PUT_DEPLOY,
+        json=request(constants.RPC_ACCOUNT_PUT_DEPLOY),
         deploy=encode_deploy(deploy)
         )
 
-    return response.data.result["deploy_hash"]
+    return parse(response.json()).result["deploy_hash"]

--- a/pycspr/api/put_deploy.py
+++ b/pycspr/api/put_deploy.py
@@ -21,8 +21,8 @@ def execute(connection_info: NodeConnectionInfo, deploy: Deploy) -> str:
     """
     response = requests.post(
         connection_info.address_rpc,
-        json=request(constants.RPC_ACCOUNT_PUT_DEPLOY),
-        deploy=encode_deploy(deploy)
+        json=request(constants.RPC_ACCOUNT_PUT_DEPLOY,
+            {"deploy":encode_deploy(deploy)})
         )
 
     return parse(response.json()).result["deploy_hash"]


### PR DESCRIPTION
The current development takes into account #4 and fixes it uniformly for each one of the files where the `jsonrpcclient` is used:

pycspr/api/get_node_peers.py
pycspr/api/get_account_info.py
pycspr/api/get_state_item.py
pycspr/api/get_auction_info.py
pycspr/api/get_block_transfers.py
pycspr/api/get_state_root_hash.py
pycspr/api/put_deploy.py
pycspr/api/get_block.py
pycspr/api/get_rpc_schema.py
pycspr/api/get_deploy.py
pycspr/api/get_dictionary_item.py
pycspr/api/get_era_info.py
pycspr/api/get_account_balance.py
pycspr/api/get_node_status.py